### PR TITLE
Fix streaming out of order bug

### DIFF
--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -125,17 +125,14 @@ const useSubmit = () => {
 
           // TODO: have this dynamically update
           const delayPerCharacter = 4;
-          let delay = 0;
 
-          resultString.split('').forEach((character) => {
-            setTimeout(() => {
-              const updatedChats: ChatInterface[] = JSON.parse(JSON.stringify(useStore.getState().chats));
-              const updatedMessages = updatedChats[currentChatIndex].messages;
-              updatedMessages[updatedMessages.length - 1].content += character;
-              setChats(updatedChats);
-            }, delay);
-            delay += delayPerCharacter;
-          });
+          for (const c of resultString.split('')) {
+            await new Promise((resolve) => setTimeout(resolve, delayPerCharacter));
+            const updatedChats: ChatInterface[] = JSON.parse(JSON.stringify(useStore.getState().chats));
+            const updatedMessages = updatedChats[currentChatIndex].messages;
+            updatedMessages[updatedMessages.length - 1].content += c;
+            setChats(updatedChats);
+          }
         }
       }
 

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -103,6 +103,15 @@ const useSubmit = () => {
       let reading = true;
       let partial = '';
 
+      // TODO: have this dynamically update
+      let delayPerCharacter = 4;
+      const skipStreamDelay = (e: KeyboardEvent)=>{
+        if(e.code === 'Escape'){
+          delayPerCharacter = 0;
+        }
+      };
+      window.addEventListener('keypress', skipStreamDelay);
+
       while (reading && useStore.getState().generating) {
         const { done, value } = await reader.read();
         const result = parseEventSource(
@@ -123,9 +132,6 @@ const useSubmit = () => {
             return output;
           }, '');
 
-          // TODO: have this dynamically update
-          const delayPerCharacter = 4;
-
           for (const c of resultString.split('')) {
             await new Promise((resolve) => setTimeout(resolve, delayPerCharacter));
             const updatedChats: ChatInterface[] = JSON.parse(JSON.stringify(useStore.getState().chats));
@@ -135,6 +141,8 @@ const useSubmit = () => {
           }
         }
       }
+
+      window.removeEventListener('keypress', skipStreamDelay);
 
       if (useStore.getState().generating) {
         reader.cancel('Cancelled by user');


### PR DESCRIPTION
Fixed a bug where `setTimeout`s would terminate out of order and result in garbled output.

Also added a feature where pressing the Escape key skips the visual streaming delay for the current completion. 